### PR TITLE
Fix type mapping to match how the geometry type mapping works

### DIFF
--- a/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
+++ b/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
+++ b/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/AbrahamicContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/AbrahamicContext.cs
@@ -8,6 +8,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models
             = new TestLoggerFactory();
 
         public DbSet<Patriarch> Patriarchy { get; set; }
+        public DbSet<ConvertedPatriarch> ConvertedPatriarchy { get; set; }
 
         public string Sql
             => _loggerFactory.Logger.Sql;
@@ -20,7 +21,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models
                 .UseLoggerFactory(_loggerFactory);
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<Patriarch>()
+        {
+            modelBuilder.Entity<Patriarch>()
                 .HasData(
                     new Patriarch { Id = HierarchyId.GetRoot(), Name = "Abraham" },
                     new Patriarch { Id = HierarchyId.Parse("/1/"), Name = "Isaac" },
@@ -38,5 +40,30 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models
                     new Patriarch { Id = HierarchyId.Parse("/1/1/11.1/"), Name = "Ephraim" },
                     new Patriarch { Id = HierarchyId.Parse("/1/1/11.2/"), Name = "Manasseh" },
                     new Patriarch { Id = HierarchyId.Parse("/1/1/12/"), Name = "Benjamin" });
+
+            modelBuilder.Entity<ConvertedPatriarch>(b =>
+            {
+                b.Property(e => e.HierarchyId)
+                    .HasConversion(v => HierarchyId.Parse(v), v => v.ToString());
+
+                b.HasData(
+                    new ConvertedPatriarch { Id = 1, HierarchyId = HierarchyId.GetRoot().ToString(), Name = "Abraham" },
+                    new ConvertedPatriarch { Id = 2, HierarchyId = HierarchyId.Parse("/1/").ToString(), Name = "Isaac" },
+                    new ConvertedPatriarch { Id = 3, HierarchyId = HierarchyId.Parse("/1/1/").ToString(), Name = "Jacob" },
+                    new ConvertedPatriarch { Id = 4, HierarchyId = HierarchyId.Parse("/1/1/1/").ToString(), Name = "Reuben" },
+                    new ConvertedPatriarch { Id = 5, HierarchyId = HierarchyId.Parse("/1/1/2/").ToString(), Name = "Simeon" },
+                    new ConvertedPatriarch { Id = 6, HierarchyId = HierarchyId.Parse("/1/1/3/").ToString(), Name = "Levi" },
+                    new ConvertedPatriarch { Id = 7, HierarchyId = HierarchyId.Parse("/1/1/4/").ToString(), Name = "Judah" },
+                    new ConvertedPatriarch { Id = 8, HierarchyId = HierarchyId.Parse("/1/1/5/").ToString(), Name = "Issachar" },
+                    new ConvertedPatriarch { Id = 9, HierarchyId = HierarchyId.Parse("/1/1/6/").ToString(), Name = "Zebulun" },
+                    new ConvertedPatriarch { Id = 10, HierarchyId = HierarchyId.Parse("/1/1/7/").ToString(), Name = "Dan" },
+                    new ConvertedPatriarch { Id = 11, HierarchyId = HierarchyId.Parse("/1/1/8/").ToString(), Name = "Naphtali" },
+                    new ConvertedPatriarch { Id = 12, HierarchyId = HierarchyId.Parse("/1/1/9/").ToString(), Name = "Gad" },
+                    new ConvertedPatriarch { Id = 13, HierarchyId = HierarchyId.Parse("/1/1/10/").ToString(), Name = "Asher" },
+                    new ConvertedPatriarch { Id = 14, HierarchyId = HierarchyId.Parse("/1/1/11.1/").ToString(), Name = "Ephraim" },
+                    new ConvertedPatriarch { Id = 15, HierarchyId = HierarchyId.Parse("/1/1/11.2/").ToString(), Name = "Manasseh" },
+                    new ConvertedPatriarch { Id = 16, HierarchyId = HierarchyId.Parse("/1/1/12/").ToString(), Name = "Benjamin" });
+            });
+        }
     }
 }

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/ConvertedPatriarch.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/ConvertedPatriarch.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models
+{
+    class ConvertedPatriarch
+    {
+        public int Id { get; set; }
+        public string HierarchyId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/AnonymousArraySeedContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/AnonymousArraySeedContext.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
 {
-    internal sealed class AnonymousArraySeedContext : MigrationContext<Patriarch>
+    internal sealed class AnonymousArraySeedContext : MigrationContext<Patriarch, ConvertedPatriarch>
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -12,6 +12,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
                 new { Id = HierarchyId.GetRoot(), Name = "Eddard Stark" },
                 new { Id = HierarchyId.Parse("/1/"), Name = "Robb Stark" },
                 new { Id = HierarchyId.Parse("/2/"), Name = "Jon Snow" });
+
+            modelBuilder.Entity<ConvertedPatriarch>(b =>
+            {
+                b.Property(e => e.HierarchyId)
+                    .HasConversion(v => HierarchyId.Parse(v), v => v.ToString());
+
+                b.HasData(
+                    new ConvertedPatriarch { Id = 1, HierarchyId = HierarchyId.GetRoot().ToString(), Name = "Eddard Stark" },
+                    new ConvertedPatriarch { Id = 2, HierarchyId = HierarchyId.Parse("/1/").ToString(), Name = "Robb Stark" },
+                    new ConvertedPatriarch { Id = 3, HierarchyId = HierarchyId.Parse("/2/").ToString(), Name = "Jon Snow" });
+            });
         }
 
         public override string GetExpectedMigrationCode(string migrationName, string rootNamespace)
@@ -26,6 +37,19 @@ namespace {rootNamespace}.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {{
             migrationBuilder.CreateTable(
+                name: ""{nameof(ConvertedTestModels)}"",
+                columns: table => new
+                {{
+                    Id = table.Column<int>(type: ""int"", nullable: false),
+                    HierarchyId = table.Column<{nameof(HierarchyId)}>(type: ""hierarchyid"", nullable: true),
+                    Name = table.Column<string>(type: ""nvarchar(max)"", nullable: true)
+                }},
+                constraints: table =>
+                {{
+                    table.PrimaryKey(""PK_ConvertedTestModels"", x => x.Id);
+                }});
+
+            migrationBuilder.CreateTable(
                 name: ""{nameof(TestModels)}"",
                 columns: table => new
                 {{
@@ -38,23 +62,31 @@ namespace {rootNamespace}.Migrations
                 }});
 
             migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""), ""Eddard Stark"" }});
+                table: ""ConvertedTestModels"",
+                columns: new[] {{ ""Id"", ""HierarchyId"", ""Name"" }},
+                values: new object[,]
+                {{
+                    {{ 1, Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""), ""Eddard Stark"" }},
+                    {{ 2, Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""), ""Robb Stark"" }},
+                    {{ 3, Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""), ""Jon Snow"" }}
+                }});
 
             migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""), ""Robb Stark"" }});
-
-            migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""), ""Jon Snow"" }});
+                table: ""TestModels"",
+                columns: new[] {{ ""Id"", ""Name"" }},
+                values: new object[,]
+                {{
+                    {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""), ""Eddard Stark"" }},
+                    {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""), ""Robb Stark"" }},
+                    {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""), ""Jon Snow"" }}
+                }});
         }}
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {{
+            migrationBuilder.DropTable(
+                name: ""ConvertedTestModels"");
+
             migrationBuilder.DropTable(
                 name: ""{nameof(TestModels)}"");
         }}
@@ -80,7 +112,44 @@ namespace {rootNamespace}.Migrations
         {{
 #pragma warning disable 612, 618
 
-            modelBuilder.Entity(""{ModelType.FullName}"", b =>
+            modelBuilder.Entity(""{ModelType2.FullName}"", b =>
+                {{
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    b.Property<HierarchyId>(""HierarchyId"")
+                        .HasColumnType(""hierarchyid"");
+
+                    b.Property<string>(""Name"")
+                        .HasColumnType(""nvarchar(max)"");
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""ConvertedTestModels"");
+
+                    b.HasData(
+                        new
+                        {{
+                            Id = 1,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""),
+                            Name = ""Eddard Stark""
+                        }},
+                        new
+                        {{
+                            Id = 2,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""),
+                            Name = ""Robb Stark""
+                        }},
+                        new
+                        {{
+                            Id = 3,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""),
+                            Name = ""Jon Snow""
+                        }});
+                }});
+
+            modelBuilder.Entity(""{ModelType1.FullName}"", b =>
                 {{
                     b.Property<{nameof(HierarchyId)}>(""{nameof(Patriarch.Id)}"")
                         .HasColumnType(""{SqlServerHierarchyIdTypeMappingSourcePlugin.SqlServerTypeName}"");

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/MigrationContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/MigrationContext.cs
@@ -5,15 +5,18 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
 {
-    internal abstract class MigrationContext<T> : DbContext
-        where T : class
+    internal abstract class MigrationContext<TEntity1, TEntity2> : DbContext
+        where TEntity1 : class
+        where TEntity2 : class
     {
-        protected Type ModelType { get; } = typeof(T);
+        protected Type ModelType1 { get; } = typeof(TEntity1);
+        protected Type ModelType2 { get; } = typeof(TEntity2);
 
         private Type _thisType;
         protected Type ThisType => _thisType ??= GetType();
 
-        public DbSet<T> TestModels { get; set; }
+        public DbSet<TEntity1> TestModels { get; set; }
+        public DbSet<TEntity2> ConvertedTestModels { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)
             => options

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/TypedArraySeedContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/TypedArraySeedContext.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
 {
-    internal sealed class TypedArraySeedContext : MigrationContext<Patriarch>
+    internal sealed class TypedArraySeedContext : MigrationContext<Patriarch, ConvertedPatriarch>
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -12,6 +12,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
                 new Patriarch { Id = HierarchyId.GetRoot(), Name = "Eddard Stark" },
                 new Patriarch { Id = HierarchyId.Parse("/1/"), Name = "Robb Stark" },
                 new Patriarch { Id = HierarchyId.Parse("/2/"), Name = "Jon Snow" });
+
+            modelBuilder.Entity<ConvertedPatriarch>(b =>
+            {
+                b.Property(e => e.HierarchyId)
+                    .HasConversion(v => HierarchyId.Parse(v), v => v.ToString());
+
+                b.HasData(
+                    new ConvertedPatriarch { Id = 1, HierarchyId = HierarchyId.GetRoot().ToString(), Name = "Eddard Stark" },
+                    new ConvertedPatriarch { Id = 2, HierarchyId = HierarchyId.Parse("/1/").ToString(), Name = "Robb Stark" },
+                    new ConvertedPatriarch { Id = 3, HierarchyId = HierarchyId.Parse("/2/").ToString(), Name = "Jon Snow" });
+            });
         }
 
         public override string GetExpectedMigrationCode(string migrationName, string rootNamespace)
@@ -26,6 +37,19 @@ namespace {rootNamespace}.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {{
             migrationBuilder.CreateTable(
+                name: ""{nameof(ConvertedTestModels)}"",
+                columns: table => new
+                {{
+                    {nameof(ConvertedPatriarch.Id)} = table.Column<int>(type: ""int"", nullable: false),
+                    {nameof(ConvertedPatriarch.HierarchyId)} = table.Column<{nameof(HierarchyId)}>(type: ""hierarchyid"", nullable: true),
+                    {nameof(ConvertedPatriarch.Name)} = table.Column<string>(type: ""nvarchar(max)"", nullable: true)
+                }},
+                constraints: table =>
+                {{
+                    table.PrimaryKey(""PK_{nameof(ConvertedTestModels)}"", x => x.{nameof(ConvertedPatriarch.Id)});
+                }});
+
+            migrationBuilder.CreateTable(
                 name: ""{nameof(TestModels)}"",
                 columns: table => new
                 {{
@@ -38,23 +62,31 @@ namespace {rootNamespace}.Migrations
                 }});
 
             migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""), ""Eddard Stark"" }});
+                table: ""ConvertedTestModels"",
+                columns: new[] {{ ""Id"", ""HierarchyId"", ""Name"" }},
+                values: new object[,]
+                {{
+                    {{ 1, {typeof(HierarchyId).FullName}.Parse(""/""), ""Eddard Stark"" }},
+                    {{ 2, {typeof(HierarchyId).FullName}.Parse(""/1/""), ""Robb Stark"" }},
+                    {{ 3, {typeof(HierarchyId).FullName}.Parse(""/2/""), ""Jon Snow"" }}
+                }});
 
             migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""), ""Robb Stark"" }});
-
-            migrationBuilder.InsertData(
-                table: ""{nameof(TestModels)}"",
-                columns: new[] {{ ""{nameof(Patriarch.Id)}"", ""{nameof(Patriarch.Name)}"" }},
-                values: new object[] {{ Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""), ""Jon Snow"" }});
+                table: ""TestModels"",
+                columns: new[] {{ ""Id"", ""Name"" }},
+                values: new object[,]
+                {{
+                    {{ {typeof(HierarchyId).FullName}.Parse(""/""), ""Eddard Stark"" }},
+                    {{ {typeof(HierarchyId).FullName}.Parse(""/1/""), ""Robb Stark"" }},
+                    {{ {typeof(HierarchyId).FullName}.Parse(""/2/""), ""Jon Snow"" }}
+                }});
         }}
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {{
+            migrationBuilder.DropTable(
+                name: ""ConvertedTestModels"");
+
             migrationBuilder.DropTable(
                 name: ""{nameof(TestModels)}"");
         }}
@@ -80,7 +112,44 @@ namespace {rootNamespace}.Migrations
         {{
 #pragma warning disable 612, 618
 
-            modelBuilder.Entity(""{ModelType.FullName}"", b =>
+            modelBuilder.Entity(""{ModelType2.FullName}"", b =>
+                {{
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType(""int"");
+
+                    b.Property<HierarchyId>(""HierarchyId"")
+                        .HasColumnType(""hierarchyid"");
+
+                    b.Property<string>(""Name"")
+                        .HasColumnType(""nvarchar(max)"");
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""ConvertedTestModels"");
+
+                    b.HasData(
+                        new
+                        {{
+                            Id = 1,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/""),
+                            Name = ""Eddard Stark""
+                        }},
+                        new
+                        {{
+                            Id = 2,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/1/""),
+                            Name = ""Robb Stark""
+                        }},
+                        new
+                        {{
+                            Id = 3,
+                            HierarchyId = Microsoft.EntityFrameworkCore.HierarchyId.Parse(""/2/""),
+                            Name = ""Jon Snow""
+                        }});
+                }});
+
+            modelBuilder.Entity(""{ModelType1.FullName}"", b =>
                 {{
                     b.Property<{nameof(HierarchyId)}>(""{nameof(Patriarch.Id)}"")
                         .HasColumnType(""{SqlServerHierarchyIdTypeMappingSourcePlugin.SqlServerTypeName}"");

--- a/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
+++ b/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #31

Extension type mappings use a value converter internally, but make the mapped type look like it is native to the provider--which conceptually it is. This requires that converter is used appropriately in the type mapping, most notably when creating literals.