### PR TITLE
Update to EF Core RC1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,14 +1,12 @@
-name: .NET Core
+name: .NET
 
 on:
   push:
     branches:
     - master
-    - release/1.x
   pull_request:
     branches:
     - master
-    - release/1.x
 
 jobs:
   build:
@@ -17,14 +15,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 6
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-        include-prerelease: true
-    - name: Install dependencies
+    - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,14 +17,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
+        include-prerelease: true
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/EFCore.InMemory.HierarchyId.Test/EFCore.InMemory.HierarchyId.Test.csproj
+++ b/EFCore.InMemory.HierarchyId.Test/EFCore.InMemory.HierarchyId.Test.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/EFCore.InMemory.HierarchyId.Test/EFCore.InMemory.HierarchyId.Test.csproj
+++ b/EFCore.InMemory.HierarchyId.Test/EFCore.InMemory.HierarchyId.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>EntityFrameworkCore.InMemory.HierarchyId.Test</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.InMemory</RootNamespace>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
+++ b/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.InMemory.HierarchyId</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.InMemory</RootNamespace>
     <Authors>Adrian Paul Nutiu</Authors>
@@ -10,11 +10,11 @@
     <PackageTags>EFCore;InMemory;HierarchyId</PackageTags>
     <RepositoryUrl>https://github.com/efcore/EFCore.SqlServer.HierarchyId.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Copyright>© 2020 Brice Lambson, et al. All rights reserved.</Copyright>
+    <Copyright>© 2021 Brice Lambson, et al. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.1</Version>
+    <Version>3.0.0-rc1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0-rc.1.21452.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
+++ b/EFCore.InMemory.HierarchyId/EFCore.InMemory.HierarchyId.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-rc1</Version>
+    <Version>3.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0-rc.1.21452.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.InMemory.HierarchyId/Extensions/InMemoryHierarchyIdServiceCollectionExtensions.cs
+++ b/EFCore.InMemory.HierarchyId/Extensions/InMemoryHierarchyIdServiceCollectionExtensions.cs
@@ -18,10 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection serviceCollection)
         {
             new EntityFrameworkServicesBuilder(serviceCollection)
-                .TryAddProviderSpecificServices(
-                    x => x
-                        .TryAddSingletonEnumerable<ITypeMappingSourcePlugin, InMemoryHierarchyIdTypeMappingSourcePlugin>()
-                );
+                .TryAdd<ITypeMappingSourcePlugin, InMemoryHierarchyIdTypeMappingSourcePlugin>();
 
             return serviceCollection;
         }

--- a/EFCore.InMemory.HierarchyId/Infrastructure/InMemoryHierarchyIdOptionsExtension.cs
+++ b/EFCore.InMemory.HierarchyId/Infrastructure/InMemoryHierarchyIdOptionsExtension.cs
@@ -51,8 +51,8 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure
             public override int GetServiceProviderHashCode() => 0;
 
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-                => true;
-            
+                => other is ExtensionInfo;
+
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             => debugInfo["InMemory:" + nameof(InMemoryHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId)] = "1";
 

--- a/EFCore.InMemory.HierarchyId/Infrastructure/InMemoryHierarchyIdOptionsExtension.cs
+++ b/EFCore.InMemory.HierarchyId/Infrastructure/InMemoryHierarchyIdOptionsExtension.cs
@@ -48,8 +48,11 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Infrastructure
 
             public override bool IsDatabaseProvider => false;
 
-            public override long GetServiceProviderHashCode() => 0;
+            public override int GetServiceProviderHashCode() => 0;
 
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => true;
+            
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             => debugInfo["InMemory:" + nameof(InMemoryHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId)] = "1";
 

--- a/EFCore.SqlServer.HierarchyId.Abstractions/EFCore.SqlServer.HierarchyId.Abstractions.csproj
+++ b/EFCore.SqlServer.HierarchyId.Abstractions/EFCore.SqlServer.HierarchyId.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.SqlServer.HierarchyId.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <Authors>Brice Lambson, et al.</Authors>
@@ -10,11 +10,11 @@
     <PackageTags>EFCore;SQL Server;HierarchyId</PackageTags>
     <RepositoryUrl>https://github.com/efcore/EFCore.SqlServer.HierarchyId.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Copyright>© 2020 Brice Lambson, et al. All rights reserved.</Copyright>
+    <Copyright>© 2021 Brice Lambson, et al. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.1</Version>
+    <Version>3.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>

--- a/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
+++ b/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>EntityFrameworkCore.SqlServer.HierarchyId.Test</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.SqlServer</RootNamespace>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-rc.1.21452.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
+++ b/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-rc.1.21452.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/AnonymousArraySeedContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/AnonymousArraySeedContext.cs
@@ -30,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
             return $@"using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#nullable disable
+
 namespace {rootNamespace}.Migrations
 {{
     public partial class {migrationName} : Migration
@@ -102,6 +104,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using {ThisType.Namespace};
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
 
 namespace {rootNamespace}.Migrations
 {{

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/TypedArraySeedContext.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Models/Migrations/TypedArraySeedContext.cs
@@ -30,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Test.Models.Migrations
             return $@"using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#nullable disable
+
 namespace {rootNamespace}.Migrations
 {{
     public partial class {migrationName} : Migration
@@ -102,6 +104,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using {ThisType.Namespace};
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
 
 namespace {rootNamespace}.Migrations
 {{

--- a/EFCore.SqlServer.HierarchyId.sln
+++ b/EFCore.SqlServer.HierarchyId.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31903.286
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.SqlServer.HierarchyId", "EFCore.SqlServer.HierarchyId\EFCore.SqlServer.HierarchyId.csproj", "{8F722A02-71A4-4787-ACD8-FB7D5B7AE648}"
 EndProject

--- a/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
+++ b/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.SqlServer.HierarchyId</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore.SqlServer</RootNamespace>
     <Authors>Brice Lambson, et al.</Authors>
@@ -10,11 +10,11 @@
     <PackageTags>EFCore;SQL Server;HierarchyId</PackageTags>
     <RepositoryUrl>https://github.com/efcore/EFCore.SqlServer.HierarchyId.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Copyright>© 2020 Brice Lambson, et al. All rights reserved.</Copyright>
+    <Copyright>© 2021 Brice Lambson, et al. All rights reserved.</Copyright>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.1</Version>
+    <Version>3.0.0-rc1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-rc.1.21452.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
+++ b/EFCore.SqlServer.HierarchyId/EFCore.SqlServer.HierarchyId.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0-rc1</Version>
+    <Version>3.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Features>strict</Features>
     <LangVersion>latest</LangVersion>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-rc.1.21452.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.SqlServer.HierarchyId/Extensions/SqlServerHierarchyIdServiceCollectionExtensions.cs
+++ b/EFCore.SqlServer.HierarchyId/Extensions/SqlServerHierarchyIdServiceCollectionExtensions.cs
@@ -20,9 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection serviceCollection)
         {
             new EntityFrameworkRelationalServicesBuilder(serviceCollection)
-                .TryAddProviderSpecificServices(
-                    x => x.TryAddSingletonEnumerable<IMethodCallTranslatorPlugin, SqlServerHierarchyIdMethodCallTranslatorPlugin>()
-                        .TryAddSingletonEnumerable<IRelationalTypeMappingSourcePlugin, SqlServerHierarchyIdTypeMappingSourcePlugin>());
+                .TryAdd<IMethodCallTranslatorPlugin, SqlServerHierarchyIdMethodCallTranslatorPlugin>()
+                .TryAdd<IRelationalTypeMappingSourcePlugin, SqlServerHierarchyIdTypeMappingSourcePlugin>();
 
             return serviceCollection;
         }

--- a/EFCore.SqlServer.HierarchyId/Infrastructure/SqlServerHierarchyIdOptionsExtension.cs
+++ b/EFCore.SqlServer.HierarchyId/Infrastructure/SqlServerHierarchyIdOptionsExtension.cs
@@ -53,9 +53,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure
             public override bool IsDatabaseProvider => false;
 
             public override int GetServiceProviderHashCode() => 0;
-            
-            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) 
-                => true;
+
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+                => other is ExtensionInfo;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             => debugInfo["SqlServer:" + nameof(SqlServerHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId)] = "1";

--- a/EFCore.SqlServer.HierarchyId/Infrastructure/SqlServerHierarchyIdOptionsExtension.cs
+++ b/EFCore.SqlServer.HierarchyId/Infrastructure/SqlServerHierarchyIdOptionsExtension.cs
@@ -52,7 +52,10 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure
 
             public override bool IsDatabaseProvider => false;
 
-            public override long GetServiceProviderHashCode() => 0;
+            public override int GetServiceProviderHashCode() => 0;
+            
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) 
+                => true;
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
             => debugInfo["SqlServer:" + nameof(SqlServerHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId)] = "1";

--- a/EFCore.SqlServer.HierarchyId/Scaffolding/SqlServerHierarchyIdCodeGeneratorPlugin.cs
+++ b/EFCore.SqlServer.HierarchyId/Scaffolding/SqlServerHierarchyIdCodeGeneratorPlugin.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore.Design;
+﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding
@@ -8,7 +10,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding
         public override MethodCallCodeFragment GenerateProviderOptions()
         {
             return new MethodCallCodeFragment(
-                nameof(SqlServerHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId));
+                typeof(SqlServerHierarchyIdDbContextOptionsBuilderExtensions).GetRuntimeMethod(
+                    nameof(SqlServerHierarchyIdDbContextOptionsBuilderExtensions.UseHierarchyId),
+                    new[] { typeof(SqlServerDbContextOptionsBuilder) }));
         }
     }
 }


### PR DESCRIPTION
* Fixed service provider hashing
* Fixed registration of services to use correct scope
* Updated version to 3.0.0-rc1
* Updated Copyright
* Target .NET 6
* Added nullable disable to Migrations tests

