### PR TITLE
Correctly interpret store hierarchy type in type mapping for scaffolding

### DIFF
--- a/EFCore.SqlServer.HierarchyId.Test/CSharpDbContextGeneratorTest.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/CSharpDbContextGeneratorTest.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.SqlServer.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer;
+
+public class CSharpDbContextGeneratorTest : ModelCodeGeneratorTestBase
+{
+    [ConditionalFact]
+    public void Generates_context_with_UseHierarchyId()
+        => Test(
+            modelBuilder =>
+            {
+                modelBuilder.Entity(
+                    "Patriarch",
+                    b =>
+                    {
+                        b.Property<HierarchyId>("Id");
+                        b.HasKey("Id");
+                        b.Property<string>("Name");
+                    });
+            },
+            new ModelCodeGenerationOptions {UseDataAnnotations = false},
+            code =>
+            {
+                AssertFileContents(
+                    @"using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        public TestDbContext()
+        {
+        }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public virtual DbSet<Patriarch> Patriarch { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see http://go.microsoft.com/fwlink/?LinkId=723263.
+                optionsBuilder.UseSqlServer(""Initial Catalog=TestDatabase"", x => x.UseHierarchyId());
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+",
+                    code.ContextFile);
+            });
+}

--- a/EFCore.SqlServer.HierarchyId.Test/CSharpEntityTypeGeneratorTest.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/CSharpEntityTypeGeneratorTest.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer;
+
+public class CSharpEntityTypeGeneratorTest : ModelCodeGeneratorTestBase
+{
+    [ConditionalFact]
+    public void Class_with_HierarchyId_key_is_generated()
+        => Test(
+            modelBuilder =>
+            {
+                modelBuilder.Entity(
+                    "Patriarch",
+                    b =>
+                    {
+                        b.Property<HierarchyId>("Id");
+                        b.HasKey("Id");
+                        b.Property<string>("Name");
+                    });
+            },
+            new ModelCodeGenerationOptions { UseDataAnnotations = true },
+            code =>
+            {
+                AssertFileContents(
+                    @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace TestNamespace
+{
+    public partial class Patriarch
+    {
+        [Key]
+        public HierarchyId Id { get; set; }
+        public string Name { get; set; }
+    }
+}
+",
+                    code.AdditionalFiles.Single(f => f.Path == "Patriarch.cs"));
+            });
+
+    [ConditionalFact]
+    public void Class_with_HierarchyId_property_is_generated()
+        => Test(
+            modelBuilder =>
+            {
+                modelBuilder.Entity(
+                    "Patriarch",
+                    b =>
+                    {
+                        b.Property<int>("Id");
+                        b.HasKey("Id");
+                        b.Property<string>("Name");
+                        b.Property<HierarchyId>("Hierarchy");
+                    });
+            },
+            new ModelCodeGenerationOptions { UseDataAnnotations = true },
+            code =>
+            {
+                AssertFileContents(
+                    @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace TestNamespace
+{
+    public partial class Patriarch
+    {
+        [Key]
+        public int Id { get; set; }
+        public HierarchyId Hierarchy { get; set; }
+        public string Name { get; set; }
+    }
+}
+",
+                    code.AdditionalFiles.Single(f => f.Path == "Patriarch.cs"));
+            });
+
+    [ConditionalFact]
+    public void Class_with_multiple_HierarchyId_properties_are_generated()
+        => Test(
+            modelBuilder =>
+            {
+                modelBuilder.Entity(
+                    "Patriarch",
+                    b =>
+                    {
+                        b.Property<HierarchyId>("Id");
+                        b.HasKey("Id");
+                        b.Property<string>("Name");
+                        b.Property<HierarchyId>("Hierarchy");
+                    });
+            },
+            new ModelCodeGenerationOptions { UseDataAnnotations = true },
+            code =>
+            {
+                AssertFileContents(
+                    @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace TestNamespace
+{
+    public partial class Patriarch
+    {
+        [Key]
+        public HierarchyId Id { get; set; }
+        public HierarchyId Hierarchy { get; set; }
+        public string Name { get; set; }
+    }
+}
+",
+                    code.AdditionalFiles.Single(f => f.Path == "Patriarch.cs"));
+            });
+}

--- a/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
+++ b/EFCore.SqlServer.HierarchyId.Test/EFCore.SqlServer.HierarchyId.Test.csproj
@@ -12,7 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/EFCore.SqlServer.HierarchyId.Test/ModelCodeGeneratorTestBase.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/ModelCodeGeneratorTestBase.cs
@@ -1,0 +1,66 @@
+using System;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer;
+
+#pragma warning disable EF1001
+
+public abstract class ModelCodeGeneratorTestBase
+{
+    protected void Test(
+        Action<ModelBuilder> buildModel,
+        ModelCodeGenerationOptions options,
+        Action<ScaffoldedModel> assertScaffold)
+    {
+        var designServices = new ServiceCollection();
+        AddModelServices(designServices);
+
+        var modelBuilder = SqlServerTestHelpers.Instance.CreateConventionBuilder(customServices: designServices);
+        modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion);
+        buildModel(modelBuilder);
+
+        var model = modelBuilder.FinalizeModel(designTime: true, skipValidation: true);
+
+        var services = CreateServices();
+        AddScaffoldingServices(services);
+
+        var generator = services.BuildServiceProvider(validateScopes: true)
+            .GetRequiredService<IModelCodeGenerator>();
+
+        options.ModelNamespace ??= "TestNamespace";
+        options.ContextName = "TestDbContext";
+        options.ConnectionString = "Initial Catalog=TestDatabase";
+
+        var scaffoldedModel = generator.GenerateModel(
+            model,
+            options);
+        assertScaffold(scaffoldedModel);
+    }
+
+    private static IServiceCollection CreateServices()
+    {
+        var testAssembly = typeof(ModelCodeGeneratorTestBase).Assembly;
+        var reporter = new TestOperationReporter();
+        var services = new DesignTimeServicesBuilder(testAssembly, testAssembly, reporter, new string[0])
+            .CreateServiceCollection("Microsoft.EntityFrameworkCore.SqlServer");
+        return services;
+    }
+
+    protected virtual void AddModelServices(IServiceCollection services)
+    {
+    }
+
+    protected virtual void AddScaffoldingServices(IServiceCollection services)
+    {
+    }
+
+    protected static void AssertFileContents(
+        string expectedCode,
+        ScaffoldedFile file)
+        => Assert.Equal(expectedCode, file.Code, ignoreLineEndingDifferences: true);
+}

--- a/EFCore.SqlServer.HierarchyId.Test/RelationalScaffoldingModelFactoryTest.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/RelationalScaffoldingModelFactoryTest.cs
@@ -1,0 +1,121 @@
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer;
+
+#pragma warning disable EF1001
+
+public class RelationalScaffoldingModelFactoryTest
+{
+    private readonly IScaffoldingModelFactory _factory;
+    private readonly TestOperationReporter _reporter;
+
+    private static readonly DatabaseModel Database;
+    private static readonly DatabaseTable Table;
+    private static readonly DatabaseColumn IdColumn;
+    private static readonly DatabasePrimaryKey IdPrimaryKey;
+
+    static RelationalScaffoldingModelFactoryTest()
+    {
+        Database = new DatabaseModel();
+        Table = new DatabaseTable { Database = Database, Name = "Foo" };
+        IdColumn = new DatabaseColumn
+        {
+            Table = Table,
+            Name = "Id",
+            StoreType = "int"
+        };
+        IdPrimaryKey = new DatabasePrimaryKey
+        {
+            Table = Table,
+            Name = "IdPrimaryKey",
+            Columns = { IdColumn }
+        };
+    }
+
+    public RelationalScaffoldingModelFactoryTest()
+    {
+        _reporter = new TestOperationReporter();
+
+        var assembly = typeof(RelationalScaffoldingModelFactoryTest).Assembly;
+        _factory = new DesignTimeServicesBuilder(assembly, assembly, _reporter, new string[0])
+            .CreateServiceCollection("Microsoft.EntityFrameworkCore.SqlServer")
+            .AddSingleton<IScaffoldingModelFactory, FakeScaffoldingModelFactory>()
+            .BuildServiceProvider(validateScopes: true)
+            .GetRequiredService<IScaffoldingModelFactory>();
+
+        _reporter.Clear();
+    }
+
+    [ConditionalFact]
+    public void Loads_HierarchyId_columns()
+    {
+        var info = new DatabaseModel
+        {
+            Tables =
+            {
+                new DatabaseTable
+                {
+                    Database = Database,
+                    Name = "Jobs",
+                    Columns =
+                    {
+                        IdColumn,
+                        new DatabaseColumn
+                        {
+                            Table = Table,
+                            Name = "occupation",
+                            StoreType = "nvarchar(max)",
+                            DefaultValueSql = "\"dev\""
+                        },
+                        new DatabaseColumn
+                        {
+                            Table = Table,
+                            Name = "salary",
+                            StoreType = "int",
+                            IsNullable = true
+                        },
+                        new DatabaseColumn
+                        {
+                            Table = Table,
+                            Name = "hierarchy",
+                            StoreType = "HierarchyId"
+                        }
+                    },
+                    PrimaryKey = IdPrimaryKey
+                }
+            }
+        };
+
+        var entityType =
+            (EntityType)_factory.Create(info, new ModelReverseEngineerOptions { NoPluralize = true }).FindEntityType("Jobs");
+
+        Assert.Collection(
+            entityType.GetProperties(),
+            pk =>
+            {
+                Assert.Equal("Id", pk.Name);
+                Assert.Equal(typeof(int), pk.ClrType);
+            },
+            column =>
+            {
+                Assert.Equal("hierarchy", column.GetColumnBaseName());
+                Assert.Equal(typeof(HierarchyId), column.ClrType);
+            },
+            column =>
+            {
+                Assert.Equal("occupation", column.GetColumnBaseName());
+                Assert.Equal(typeof(string), column.ClrType);
+            },
+            column =>
+            {
+                Assert.Equal("salary", column.GetColumnBaseName());
+                Assert.Equal(typeof(int?), column.ClrType);
+            });
+    }
+}

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Utilities/FakeScaffoldingModelFactory.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Utilities/FakeScaffoldingModelFactory.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+#pragma warning disable EF1001
+
+public class FakeScaffoldingModelFactory : RelationalScaffoldingModelFactory
+{
+    public FakeScaffoldingModelFactory(
+        IOperationReporter reporter,
+        ICandidateNamingService candidateNamingService,
+        IPluralizer pluralizer,
+        ICSharpUtilities cSharpUtilities,
+        IScaffoldingTypeMapper scaffoldingTypeMapper,
+        LoggingDefinitions loggingDefinitions,
+        IModelRuntimeInitializer modelRuntimeInitializer)
+        : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper,
+            loggingDefinitions, modelRuntimeInitializer)
+    {
+    }
+
+    public override IModel Create(DatabaseModel databaseModel, ModelReverseEngineerOptions options)
+    {
+        foreach (var sequence in databaseModel.Sequences)
+        {
+            sequence.Database = databaseModel;
+        }
+
+        foreach (var table in databaseModel.Tables)
+        {
+            table.Database = databaseModel;
+
+            foreach (var column in table.Columns)
+            {
+                column.Table = table;
+            }
+
+            if (table.PrimaryKey != null)
+            {
+                table.PrimaryKey.Table = table;
+                FixupColumns(table, table.PrimaryKey.Columns);
+            }
+
+            foreach (var index in table.Indexes)
+            {
+                index.Table = table;
+                FixupColumns(table, index.Columns);
+            }
+
+            foreach (var uniqueConstraints in table.UniqueConstraints)
+            {
+                uniqueConstraints.Table = table;
+                FixupColumns(table, uniqueConstraints.Columns);
+            }
+
+            foreach (var foreignKey in table.ForeignKeys)
+            {
+                foreignKey.Table = table;
+                FixupColumns(table, foreignKey.Columns);
+
+                if (foreignKey.PrincipalTable is DatabaseTableRef tableRef)
+                {
+                    foreignKey.PrincipalTable = databaseModel.Tables
+                        .First(t => t.Name == tableRef.Name && t.Schema == tableRef.Schema);
+                }
+
+                FixupColumns(foreignKey.PrincipalTable, foreignKey.PrincipalColumns);
+            }
+        }
+
+        return base.Create(databaseModel, options);
+    }
+
+    private static void FixupColumns(DatabaseTable table, IList<DatabaseColumn> columns)
+    {
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (columns[i] is DatabaseColumnRef columnRef)
+            {
+                columns[i] = table.Columns.First(c => c.Name == columnRef.Name);
+            }
+
+            columns[i].Table = table;
+        }
+    }
+}
+
+internal class DatabaseTableRef : DatabaseTable
+{
+    public DatabaseTableRef(string name, string schema = null)
+    {
+        Name = name;
+        Schema = schema;
+    }
+
+    public override DatabaseModel Database
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override string Comment
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override DatabasePrimaryKey PrimaryKey
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override IList<DatabaseColumn> Columns
+        => throw new NotImplementedException();
+
+    public override IList<DatabaseUniqueConstraint> UniqueConstraints
+        => throw new NotImplementedException();
+
+    public override IList<DatabaseIndex> Indexes
+        => throw new NotImplementedException();
+
+    public override IList<DatabaseForeignKey> ForeignKeys
+        => throw new NotImplementedException();
+}
+
+internal class DatabaseColumnRef : DatabaseColumn
+{
+    public DatabaseColumnRef(string name)
+    {
+        Name = name;
+    }
+
+    public override DatabaseTable Table
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override bool IsNullable
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override string StoreType
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override string DefaultValueSql
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override string ComputedColumnSql
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override string Comment
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    public override ValueGenerated? ValueGenerated
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+}

--- a/EFCore.SqlServer.HierarchyId.Test/Test/Utilities/SqlServerTestHelpers.cs
+++ b/EFCore.SqlServer.HierarchyId.Test/Test/Utilities/SqlServerTestHelpers.cs
@@ -1,0 +1,25 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.SqlServer.Diagnostics.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities;
+
+#pragma warning disable EF1001
+
+public class SqlServerTestHelpers : TestHelpers
+{
+    private SqlServerTestHelpers()
+    {
+    }
+
+    public static SqlServerTestHelpers Instance { get; } = new();
+
+    public override IServiceCollection AddProviderServices(IServiceCollection services)
+        => services.AddEntityFrameworkSqlServer();
+
+    public override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlServer(new SqlConnection("Database=DummyDatabase"));
+
+    public override LoggingDefinitions LoggingDefinitions { get; } = new SqlServerLoggingDefinitions();
+}

--- a/EFCore.SqlServer.HierarchyId/Storage/SqlServerHierarchyIdTypeMappingSourcePlugin.cs
+++ b/EFCore.SqlServer.HierarchyId/Storage/SqlServerHierarchyIdTypeMappingSourcePlugin.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
@@ -11,7 +12,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
             var clrType = mappingInfo.ClrType;
             var storeTypeName = mappingInfo.StoreTypeName;
 
-            return typeof(HierarchyId).IsAssignableFrom(clrType) || storeTypeName == SqlServerTypeName
+            return typeof(HierarchyId).IsAssignableFrom(clrType)
+                   || SqlServerTypeName.Equals(storeTypeName, StringComparison.OrdinalIgnoreCase)
                 ? new SqlServerHierarchyIdTypeMapping(SqlServerTypeName, clrType ?? typeof(HierarchyId))
                 : null;
         }


### PR DESCRIPTION
Fixes #86

This issue was partly fixed by PR #73, by @yuryjhol, who reported the code issue as #72, although at that time without communication of a functional impact.

This change adds more scaffolding tests, and also makes the name check case-insensitive.